### PR TITLE
Add `netcat` to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu
 
 RUN apt update
 
-RUN apt-get install -y curl procps wget zip unzip && \
+RUN apt-get install -y curl procps netcat wget zip unzip && \
 	apt-get install -y default-jre && \
 	apt-get install -y maven && \
 	wget https://github.com/spring-cloud/spring-cloud-function/archive/refs/tags/v3.1.6.zip && \


### PR DESCRIPTION
So a reverse shell can easily be demoed.